### PR TITLE
Speed constant style

### DIFF
--- a/client/src/components/Visualiser/Controller/Terminal/Terminal.tsx
+++ b/client/src/components/Visualiser/Controller/Terminal/Terminal.tsx
@@ -98,7 +98,7 @@ const Terminal: FC<Props> = ({ executeCommand, topicTitle }) => {
         {showMan ? (
           <div>
             <Typist cursor={{ hideWhenDone: true }} avgTypingDelay={30}>
-              Type :q + Enter to exit
+              Type :q + Enter to exit.
             </Typist>
           </div>
         ) : (

--- a/client/src/components/Visualiser/VisualiserManager.tsx
+++ b/client/src/components/Visualiser/VisualiserManager.tsx
@@ -10,6 +10,7 @@ import GUIMode from './Controller/GUIMode/GUIMode';
 import { Terminal } from './Controller/Terminal';
 import styles from './VisualiserDashboard.module.scss';
 import getCommandExecutor from './executableCommands';
+import { defaultSpeed } from '../../constants/speed';
 
 interface Props {
   topicTitle: string;
@@ -27,7 +28,7 @@ interface Props {
  */
 const VisualiserInterface: React.FC<Props> = ({ topicTitle }) => {
   const [timelineComplete, setTimelineComplete] = useState<boolean>(false);
-  const [speed, setSpeed] = useState<number>(0.6);
+  const [speed, setSpeed] = useState<number>(defaultSpeed);
   const [terminalMode, setTerminalMode] = useState(true);
 
   const [visualiser, setVisualiser] = useState<any>({});

--- a/client/src/constants/speed.ts
+++ b/client/src/constants/speed.ts
@@ -1,0 +1,1 @@
+export const defaultSpeed = 0.6;

--- a/client/src/visualiser-src/linked-list-visualiser/initialiser.ts
+++ b/client/src/visualiser-src/linked-list-visualiser/initialiser.ts
@@ -1,7 +1,7 @@
 import AnimationProducer from '../common/AnimationProducer';
 import Controller from '../controller/AnimationController';
 import LinkedList from './data-structure/GraphicalLinkedList';
-import { defaultSpeed } from './util/constants';
+import { defaultSpeed } from '../../constants/speed';
 
 // for documentation read: https://compclub.atlassian.net/wiki/spaces/S/pages/2150892071/Documentation#Visualiser-Docs%3A
 

--- a/client/src/visualiser-src/linked-list-visualiser/util/constants.ts
+++ b/client/src/visualiser-src/linked-list-visualiser/util/constants.ts
@@ -54,5 +54,3 @@ export const pathAttributes = {
   class: 'path',
   opacity: 0,
 };
-
-// Animation attributes

--- a/client/src/visualiser-src/linked-list-visualiser/util/constants.ts
+++ b/client/src/visualiser-src/linked-list-visualiser/util/constants.ts
@@ -56,4 +56,4 @@ export const pathAttributes = {
 };
 
 // Animation attributes
-export const defaultSpeed = 0.6;
+// export const defaultSpeed = 0.6;

--- a/client/src/visualiser-src/linked-list-visualiser/util/constants.ts
+++ b/client/src/visualiser-src/linked-list-visualiser/util/constants.ts
@@ -56,4 +56,3 @@ export const pathAttributes = {
 };
 
 // Animation attributes
-// export const defaultSpeed = 0.6;


### PR DESCRIPTION
I noticed there was a constants folder (client > src > constants) with multiple files to store different constants. So to stay consistent, I also created a file names speed.ts to store the constant for defaultSpeed and stored it in this directory.

One other thing to note is that defaultSpeed is also a constant defined in a file called constants.ts in src>visualiser-src > util and the linked-list-visualiser file is using this one instead. Should I make it so the linked list visualiser used the main speed constant from the constants folder instead. 
