### PR TITLE
Eq/bugfix switching topics

### DIFF
--- a/client/src/components/Navbars/TopNavbar.tsx
+++ b/client/src/components/Navbars/TopNavbar.tsx
@@ -159,10 +159,13 @@ const TopNavbar: FC<Props> = ({ position = 'fixed', enableOnScrollEffect = true 
     >
       {getTopics() &&
         getTopics().map((topic, idx) => (
-          <MenuItem key={idx} className={styles.item}>
-            <Link to={`/visualiser/${titleToUrl(topic)}`}>
-              <span>{topic}</span>
-            </Link>
+          <MenuItem
+            key={idx}
+            className={styles.item}
+            component={Link}
+            to={`/visualiser/${titleToUrl(topic)}`}
+          >
+            {topic}
           </MenuItem>
         ))}
     </Menu>

--- a/client/src/visualiser-src/linked-list-visualiser/data-structure/GraphicalLinkedList.ts
+++ b/client/src/visualiser-src/linked-list-visualiser/data-structure/GraphicalLinkedList.ts
@@ -186,6 +186,7 @@ export default class GraphicalLinkedList extends GraphicalDataStructure {
     producer.doAnimationAndHighlight(1, producer.createNodeAt, index, newNode, this.length);
     if (index === 0 && this.head !== null) {
       newNode.next = this.head;
+      this.head = newNode;
       producer.doAnimationAndHighlight(3, producer.newHeadPointToOldHead, newNode);
       producer.doAnimationAndHighlight(
         7,


### PR DESCRIPTION
Fixed switching between topics in the navbar: Link is now applied to entire menuitem rather than the topic text
Also fixed insertion at 0
whoops whoops whoops whoops whoops