### PR TITLE
Feat/canvas scroll zoom

### DIFF
--- a/client/src/components/Navbars/TopNavbar.tsx
+++ b/client/src/components/Navbars/TopNavbar.tsx
@@ -31,7 +31,7 @@ const StyledCheckIcon = styled(CheckIcon)(({ theme }) => ({
 }));
 
 interface Props {
-  position?: 'fixed' | 'static';
+  position?: 'fixed' | 'static' | 'sticky';
 }
 
 const TopNavbar: FC<Props> = ({ position = 'fixed' }) => {

--- a/client/src/components/Visualiser/VisualiserCanvas.tsx
+++ b/client/src/components/Visualiser/VisualiserCanvas.tsx
@@ -12,11 +12,13 @@ import { Box } from '@mui/material';
 const VisualiserCanvas: React.FC = () => {
   const [scale, setScale] = useState(1);
   const ZOOM_SPEED = 0.05;
+  const MAX_SCALE = 2;
+  const MIN_SCALE = 0.5;
   const onScroll = (e: React.WheelEvent) => {
     if (e.deltaY < 0) {
-      setScale(Math.min(scale + ZOOM_SPEED, 2));
+      setScale(Math.min(scale + ZOOM_SPEED, MAX_SCALE));
     } else {
-      setScale(Math.max(scale - ZOOM_SPEED, 0.5));
+      setScale(Math.max(scale - ZOOM_SPEED, MIN_SCALE));
     }
   };
 

--- a/client/src/components/Visualiser/VisualiserCanvas.tsx
+++ b/client/src/components/Visualiser/VisualiserCanvas.tsx
@@ -1,5 +1,13 @@
 import React, { useState } from 'react';
 import { Box } from '@mui/material';
+import { styled } from '@mui/system';
+
+const ZoomableSvg = styled('svg')(({ scale }) => ({
+  transition: 'transform 0.2s linear',
+  transformOrigin: 'center',
+  transform: `scale(${scale})`,
+  width: '100%',
+}));
 
 /* -------------------------------------------------------------------------- */
 /*                        Visualiser-Specific Canvases                        */
@@ -30,13 +38,7 @@ const VisualiserCanvas: React.FC = () => {
       height="100vh"
       width={window.screen.width}
     >
-      <svg
-        style={{ transition: 'transform 0.2s linear', transformOrigin: 'center' }}
-        transform={`scale(${scale})`}
-        onWheel={onScroll}
-        id="visualiser-canvas"
-        width="100%"
-      />
+      <ZoomableSvg onWheel={onScroll} id="visualiser-canvas" scale={scale} />
     </Box>
   );
 };

--- a/client/src/components/Visualiser/VisualiserCanvas.tsx
+++ b/client/src/components/Visualiser/VisualiserCanvas.tsx
@@ -13,8 +13,9 @@ const VisualiserCanvas: React.FC = () => {
   const [scale, setScale] = useState(1);
   const ZOOM_SPEED = 0.05;
   const onScroll = (e: React.WheelEvent) => {
-    console.log(`scale: ${scale}`);
-    e.deltaY > 0 ? setScale(scale + ZOOM_SPEED) : setScale(scale - ZOOM_SPEED);
+    e.deltaY < 0
+      ? setScale(Math.min(scale + ZOOM_SPEED, 2))
+      : setScale(Math.max(scale - ZOOM_SPEED, 0.5));
   };
 
   return (
@@ -26,6 +27,7 @@ const VisualiserCanvas: React.FC = () => {
       width={window.screen.width}
     >
       <svg
+        style={{ transition: 'transform 0.2s linear' }}
         transform={`scale(${scale})`}
         transform-origin="center"
         onWheel={onScroll}

--- a/client/src/components/Visualiser/VisualiserCanvas.tsx
+++ b/client/src/components/Visualiser/VisualiserCanvas.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { Box } from '@mui/material';
-import { styled } from '@mui/system';
+import { styled } from '@mui/material/styles';
 
 const ZoomableSvg = styled('svg')(({ scale }) => ({
   transition: 'transform 0.2s linear',

--- a/client/src/components/Visualiser/VisualiserCanvas.tsx
+++ b/client/src/components/Visualiser/VisualiserCanvas.tsx
@@ -13,9 +13,11 @@ const VisualiserCanvas: React.FC = () => {
   const [scale, setScale] = useState(1);
   const ZOOM_SPEED = 0.05;
   const onScroll = (e: React.WheelEvent) => {
-    e.deltaY < 0
-      ? setScale(Math.min(scale + ZOOM_SPEED, 2))
-      : setScale(Math.max(scale - ZOOM_SPEED, 0.5));
+    if (e.deltaY < 0) {
+      setScale(Math.min(scale + ZOOM_SPEED, 2));
+    } else {
+      setScale(Math.max(scale - ZOOM_SPEED, 0.5));
+    }
   };
 
   return (
@@ -27,9 +29,8 @@ const VisualiserCanvas: React.FC = () => {
       width={window.screen.width}
     >
       <svg
-        style={{ transition: 'transform 0.2s linear' }}
+        style={{ transition: 'transform 0.2s linear', transformOrigin: 'center' }}
         transform={`scale(${scale})`}
-        transform-origin="center"
         onWheel={onScroll}
         id="visualiser-canvas"
         width="100%"

--- a/client/src/components/Visualiser/VisualiserCanvas.tsx
+++ b/client/src/components/Visualiser/VisualiserCanvas.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Box } from '@mui/material';
 
 /* -------------------------------------------------------------------------- */
@@ -9,10 +9,19 @@ import { Box } from '@mui/material';
  * The React component that renders the DOM elements that the visualiser
  * attaches itself to.
  */
-const VisualiserCanvas: React.FC = () => (
-  <Box id="visualiser-container" margin="auto" width={window.screen.width}>
-    <svg id="visualiser-canvas" />
-  </Box>
-);
+const VisualiserCanvas: React.FC = () => {
+  const [scale, setScale] = useState(1);
+  const ZOOM_SPEED = 0.1;
+  const onScroll = (e: React.WheelEvent) => {
+    console.log(`scale: ${scale}`);
+    e.deltaY > 0 ? setScale(scale + ZOOM_SPEED) : setScale(scale - ZOOM_SPEED);
+  };
+
+  return (
+    <Box id="visualiser-container" margin="auto" width={window.screen.width}>
+      <svg transform={`scale(${scale})`} onWheel={onScroll} id="visualiser-canvas" />
+    </Box>
+  );
+};
 
 export default VisualiserCanvas;

--- a/client/src/components/Visualiser/VisualiserCanvas.tsx
+++ b/client/src/components/Visualiser/VisualiserCanvas.tsx
@@ -11,15 +11,27 @@ import { Box } from '@mui/material';
  */
 const VisualiserCanvas: React.FC = () => {
   const [scale, setScale] = useState(1);
-  const ZOOM_SPEED = 0.1;
+  const ZOOM_SPEED = 0.05;
   const onScroll = (e: React.WheelEvent) => {
     console.log(`scale: ${scale}`);
     e.deltaY > 0 ? setScale(scale + ZOOM_SPEED) : setScale(scale - ZOOM_SPEED);
   };
 
   return (
-    <Box id="visualiser-container" margin="auto" width={window.screen.width}>
-      <svg transform={`scale(${scale})`} onWheel={onScroll} id="visualiser-canvas" />
+    <Box
+      onWheel={onScroll}
+      id="visualiser-container"
+      margin="auto"
+      height="100vh"
+      width={window.screen.width}
+    >
+      <svg
+        transform={`scale(${scale})`}
+        transform-origin="center"
+        onWheel={onScroll}
+        id="visualiser-canvas"
+        width="100%"
+      />
     </Box>
   );
 };

--- a/client/src/pages/VisualiserPage.tsx
+++ b/client/src/pages/VisualiserPage.tsx
@@ -32,7 +32,7 @@ const VisualiserPage = () => {
 
   return topic ? (
     <Box height="100vh" overflow="hidden">
-      <TopNavbar position="static" />
+      <TopNavbar position="sticky" />
       <motion.div variants={containerVariants} initial="hidden" animate="visible" exit="exit">
         <Helmet>
           <title>{topic !== undefined ? topic : 'Structs.sh'}</title>


### PR DESCRIPTION
- Scroll to zoom for SVG canvas
- As always, things break when browser isn't full screen width. Currently can't find a way to avoid this given the SVG elements are fixed, unless each SVG element is manually rewritten to adapt each time the window resizes :/


https://github.com/csesoc/structs.sh/assets/83894732/d2a373af-5355-4710-b208-545e4c8d092c




