### PR TITLE
Update renovate rules

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,8 @@
 {
   "extends": ["config:base"],
   "lockFileMaintenance": { "enabled": true, "automerge": true },
-  "prHourlyLimit": 5,
+  "prHourlyLimit": 4,
+  "prMonthlyLimit": 6,
   "labels": ["dependencies"],
   "reviewersFromCodeOwners": true,
   "packageRules": [
@@ -15,34 +16,43 @@
       "managers": ["github-actions", "dockerfile"],
       "automerge": false,
       "automergeType": "branch",
-      "addLabels": ["deps: ci-actions"]
+      "addLabels": ["deps: ci-actions"],
+      "schedule": ["before 5am on the first monday of every 4th month"]
+    },
+    {
+      "matchPackageNames": ["actions/checkout", "actions/setup-node"],
+      "managers": ["github-actions"],
+      "automerge": true,
+      "automergeType": "branch",
+      "addLabels": ["deps: ci-actions", "automerge: safe"]
     },
     {
       "matchPackageNames": ["node"],
       "allowedVersions": "<19.0.0"
     },
     {
-      "matchUpdateTypes": ["major"],
-      "automerge": false,
-      "matchPackageNames": ["vite", "@vitejs/plugin-react"],
-      "groupName": "vite & plugins",
+      "description": "Base rule for all Vite-related packages",
+      "matchPackageNames": [
+        "vite",
+        "@vitejs/plugin-react",
+        "vite-plugin-checker",
+        "vite-tsconfig-paths"
+      ],
       "addLabels": ["deps: vite"]
     },
     {
-      "matchUpdateTypes": ["patch"],
-      "groupName": "weekly patch updates",
-      "schedule": ["before 5am every monday"],
-      "addLabels": ["deps: patches"]
-    },
-    {
-      "matchUpdateTypes": ["minor"],
-      "groupName": "weekly minor updates",
-      "schedule": ["before 5am every monday"],
-      "addLabels": ["deps: minor"]
-    },
-    {
+      "extends": [":description=Base rule for all Vite-related packages"],
       "matchUpdateTypes": ["major"],
-      "addLabels": ["deps: major"]
+      "groupName": "vite & plugins (major)",
+      "automerge": false,
+      "schedule": ["before 5am on the first monday of every 5th month"]
+    },
+    {
+      "extends": [":description=Base rule for all Vite-related packages"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "vite & plugins (minor/patch)",
+      "automerge": false,
+      "schedule": ["before 5am on the first monday of every 3rd month"]
     }
   ]
 }


### PR DESCRIPTION
Update the frequency that renovate will create PRs for npm dependency updates   

⏱️ PR rate limited:

    Hourly: 5 → 4

    Monthly limit added: max 6

🗓️ New schedules:

    CI updates: every 4 months

    Safe CI actions (checkout, setup-node): auto-merge

    Vite major: every 5 months

    Vite minor/patch: every 3 months