### PR TITLE
refactor: replace regex with recursive descent parser

### DIFF
--- a/debugger/src/debugger/base_debugger.py
+++ b/debugger/src/debugger/base_debugger.py
@@ -1,4 +1,6 @@
 import os
+import logging
+
 from asyncio import (
     Event,
     Semaphore,
@@ -13,7 +15,7 @@ from pathlib import Path
 from termios import ECHO, TCSADRAIN, tcgetattr, tcsetattr
 from typing import Callable, Coroutine, assert_never
 
-from . import mi
+from . import mi_parser as mi
 from .tributary import Tributary
 
 
@@ -125,7 +127,11 @@ class BaseDebugger:
     async def _stdout_dispatch(self) -> None:
         assert self.process.stdout is not None
         while line := await self.process.stdout.readline():
-            for resp in mi.parse(line):
+            #logging.error("RAW GDB LINE: %r", line)
+            if line == b"(gdb) ":
+                continue
+            
+            for resp in mi.MIParser(line).parse():
                 match resp:
                     case mi.Result(token=t, kind=k, results=r):
                         await self._inflight_cmds.put(t, resp)

--- a/debugger/src/debugger/debugger.py
+++ b/debugger/src/debugger/debugger.py
@@ -4,7 +4,7 @@ from collections import defaultdict, deque
 
 from pydantic import BaseModel
 
-from . import mi
+from . import mi_parser as mi
 from .base_debugger import BaseDebugger
 
 
@@ -123,8 +123,8 @@ class Debugger(BaseDebugger):
             await self.run_command(f"-var-delete {sid}")
 
             res = await self.run_command(f"-data-evaluate-expression {var}")
-            value = mi.parse_c_value(res["value"])
-
+            #value = mi.parse_c_value(res["value"])
+            value = mi.CValueParser(res["value"]).parse_cvalue()
             res = await self.run_command(f"-data-evaluate-expression &{var}")
             address = res["value"].split(" ", 1)[0]
 

--- a/debugger/src/debugger/mi_parser.py
+++ b/debugger/src/debugger/mi_parser.py
@@ -18,6 +18,42 @@ class Result:
     results: dict
 
 
+@fastdataclass
+class ExecAsync:
+    token: int | None
+    kind: str
+    output: dict
+
+
+@fastdataclass
+class StatusAsync:
+    token: int | None
+    kind: str
+    output: dict
+
+
+@fastdataclass
+class NotifyAsync:
+    token: int | None
+    kind: str
+    output: dict
+
+
+@fastdataclass
+class ConsoleStream:
+    msg: str
+
+
+@fastdataclass
+class TargetStream:
+    msg: str
+
+
+@fastdataclass
+class LogStream:
+    msg: str
+
+
 class MIParserError(Exception):
     pass
 
@@ -69,7 +105,7 @@ class MIParser():
             token.append(self._current_token)
             self.advance()
         
-        return int("".join(token))
+        return int("".join(token)) if token else None
 
 
     def parse_result_class(self):
@@ -167,11 +203,72 @@ class MIParser():
             self.advance()
         self.expect("\"")
         return "".join(cstring)
-      
-
-
+    
+    def parse_ofb_record(self):
+        match self._current_token:
+            case "~" | "@" | "&":
+                return self.parse_stream_record()
+            case _:
+                return self.parse_async_record()
         
 
+    def parse_async_record(self):
+        token=self.parse_token()
+        match self._current_token:
+            case "*":
+                self.expect("*")
+                kind,output=self.parse_async_output()
+                return ExecAsync(token=token,kind=kind,output=output)
+            case "+":
+                self.expect("+")
+                kind,output=self.parse_async_output()
+                return StatusAsync(token=token,kind=kind,output=output)
+            case "=":
+                self.expect("=")
+                kind,output=self.parse_async_output()
+                return NotifyAsync(token=token,kind=kind,output=output)
+            case _:
+                raise MIParserError
+
+    def parse_stream_record(self):
+        msg=None
+        match self._current_token:
+            case "~":
+                self.expect("~")
+                msg=self.parse_cstring()
+                return ConsoleStream(msg=msg)
+            case "@":
+                self.expect("@")
+                msg=self.parse_cstring()
+                return TargetStream(msg=msg)
+            case "&":
+                self.expect("&")
+                msg=self.parse_cstring()
+                return LogStream(msg=msg)
+            case _:
+                raise MIParserError   
+
+   
+    def parse_async_output(self):
+        async_class=self.parse_async_class()
+        output={}
+        
+        while self._current_token==",":
+            self.expect(",")
+            output.update(self.parse_result())
+        
+        return async_class,output
+
+    def parse_async_class(self):
+        async_class=[]
+        while self._current_token.isalpha() or self._current_token in ["_","-"]:
+            async_class.append(self._current_token)
+            self.advance()
+
+        return "".join(async_class)
+
+    
+      
 
 if __name__=="__main__":
     from textwrap import dedent
@@ -207,10 +304,17 @@ if __name__=="__main__":
     parse=MIParser(text)
 
     #print(parse._current_record)
-    #parse.advance_sequence()
+    parse.advance_sequence()
+    parse.advance_sequence()
+    parse.advance_sequence()
+    parse.advance_record()
+    parse.advance_record()
+    parse.advance_record()
+    parse.advance_record()
     print(parse._current_record,parse._current_token)
-    temp=parse.parse_result_record()
-    print(temp.token,temp.kind,temp.results)
+    temp=parse.parse_ofb_record()
+    #print(temp.token,temp.kind,temp.output)
+    print(temp,temp.msg)
     #or i in parse._records:
     #    print(i)
     #print(iter(new_text.splitlines()))

--- a/debugger/src/debugger/mi_parser.py
+++ b/debugger/src/debugger/mi_parser.py
@@ -60,7 +60,7 @@ class MIParserError(Exception):
 
 class CursorParser():
     def __init__(self, text:str):
-        self.text=text.strip()
+        self.text=text.lstrip()
         self.split_text=self.text.split("\n(gdb) \n")
         self._sequences=iter([i.splitlines() for i in self.split_text])
         self.advance_sequence()
@@ -129,7 +129,7 @@ class MIParser(CursorParser):
 
     def parse_result_class(self):
         kind=[]
-        while self._current_token is not None and self._current_token.isalpha():
+        while self._current_token is not None and (self._current_token.isalpha() or self._current_token == "-"):
             kind.append(self._current_token)
             self.advance()
         
@@ -318,15 +318,31 @@ class MIParser(CursorParser):
 
 
 class CValueParser(CursorParser):
-#     #"{data = 5, next = 0x0}"
+    def __init__(self, text: str):
+        self.text= text.strip()
+        self._current_record = self.text
+        self._current_record_iter = iter(self._current_record)
+        self._pos= -1
+        self.advance()
 
-
-    def parse_cvalue(self):
-        
+    def parse_cvalue(self):       
+        print("ss",self._current_token,self._pos) 
         match self._current_token:
             case t if t=="{":
-                print("ss",self._current_token,self._pos)
+                
                 self.expect("{")
+
+                if self._current_token=="{":
+                    results=[]
+                    results.append(self.parse_cvalue())
+                    while self._current_token==",":
+                        self.advance()
+                        self.expect(" ")
+                        results.append(self.parse_cvalue())
+                    
+                    self.expect("}")
+                    return results
+                    
                 is_struct=self.lookahead_is_struct()
                 print(is_struct,self._current_token,self._pos)
                 if not is_struct:
@@ -347,7 +363,7 @@ class CValueParser(CursorParser):
                 self.expect("}")
                 return results
 
-            case t if t.isdigit():
+            case t if t.isdigit() or t=="-":
                 alias=False
                 is_addr=False
                 sub_val=[]
@@ -368,11 +384,18 @@ class CValueParser(CursorParser):
                 if is_addr:
                     return "".join(sub_val)
                 else:
-                    return int("".join(sub_val))  
+                    val= "".join(sub_val)
+                    try:
+                        return int(val)
+                    except ValueError:
+                        try:
+                            return float(val)
+                        except ValueError:
+                            return val
                     
-            case t if t.isalpha():
+            case t if t.isalpha() or t == "\"":
                 sub_str=[]
-                while self._current_token!="," or self._current_token=="}" or self._current_token==None:
+                while self._current_token!="," and self._current_token!="}" and self._current_token!=None:
                     sub_str.append(self._current_token)
                     self.advance()    
                 return "".join("".join(sub_str))
@@ -381,13 +404,10 @@ class CValueParser(CursorParser):
                 raise MIParserError(f"Unaddressed cvalue string: {text}")
 
     def parse_cvalues_struct(self):
+        #print(self._current_token)
         key=[]
 
-        while self._current_token!=" ":
-            if self._current_record==",":
-                is_list=True
-                break
-    
+        while self._current_token!=" ":    
             key.append(self._current_token)
             self.advance()
         
@@ -397,7 +417,8 @@ class CValueParser(CursorParser):
 
         value=self.parse_cvalue()
         key="".join(key)
-        
+
+        print({key:value})        
         return {key:value}
         
     def lookahead_is_struct(self) -> bool:
@@ -422,6 +443,7 @@ if __name__=="__main__":
         dedent(
             r"""
             @"hehehhhehe\u0000\011\n"
+            ~"hello\012world"
             ~"helloooo~!\n"
             ~"\\asdf\"1\u0000\011'"
             &"INFO:1337"
@@ -435,7 +457,7 @@ if __name__=="__main__":
             10^done,x={main="0x0",crimson="\"\"]}"},y="zzz"
             1+stopped,y={}
             2*stopped,z={}
-            3=stopped,w={}            
+            3=stopped,w={}
             (gdb) 
             ~"what\012"
             (gdb) 
@@ -444,14 +466,8 @@ if __name__=="__main__":
         #.encode()
     )
 
-    text1=(dedent(r"""
-                  {"value": "{data = 5, next = 0x0}"}
-                  """)
-                  .lstrip()
-    )
-
     parse1=MIParser(text)
-    parse2=MIParser(text1)
+  
 
     # temp1=parse1.parse()    
     # for i in temp1:
@@ -463,14 +479,24 @@ if __name__=="__main__":
     #         print(i.token,i.kind,i.output)
     #     elif isinstance(i,ConsoleStream) or isinstance(i,LogStream) or isinstance(i,TargetStream):
     #         print(i)
-    #         print(i.msg)
+    #         print(repr(i.msg),i.msg)
     
-    text="""10^done,value="{point = {x = 1, y = 2}, arr = {10, 20}, chk = {{x = 10, y = 20}, {x = 30, y = 40}, {x = 50, y = 60}}, ptr = 0x5555555592a0 ', ch = 101 'e'}" """.strip(" ")
+ 
+    # text="""10^done,value="{point = {x = 1, y = 2}, arr = {10, 20}, chk = {{x = 10, y = 20}, {x = 30, y = 40}, {x = 50, y = 60}}, ptr = 0x5555555592a0 ', ch = 101 'e'}" """.strip(" ")
+    # value=MIParser(text).parse()
+    # value=next(value).results['value']
+    # print(value)
+    # cparser=CValueParser(value)
+    # print(cparser._current_token)
+    # ans=cparser.parse_cvalue()
+    # print(type(ans),ans)
+
+
+    text=dedent(r"""10^done,value="{scalar = 1, flag = 0, msg = \"hello\012world\", tab_str = \"col1\011col2\", null_str = \"null\000byte\", nested2 = {a = 1, b = 2}, nested3 = {outer = {mid = {inner = 42}}, sibling = 99}, vec3d = {x = 1.5, y = 2.5, z = 3.5}, transform = {pos = {x = 1.0, y = 2.0, z = 3.0}, rot = {x = 0.0, y = 0.0, z = 1.0}, scale = 2.5}, arr_int = {10, 20, 30}, arr_struct = {{x = 1, y = 2}, {x = 3, y = 4}, {x = 5, y = 6}}, arr_nested = {{p = {a = 1, b = 2}, q = 3}, {p = {a = 4, b = 5}, q = 6}}, mixed = {count = 3, data = {100, 200, 300}, info = {id = 7, val = 8}}, zero_addr = 0x0, neg = -42, big = 2147483647}" """.strip(" "))
+    #text=r"""10^done,value="10" """.strip()
     value=MIParser(text).parse()
     value=next(value).results['value']
-    print(value)
     cparser=CValueParser(value)
-    print(cparser._current_token)
-    ans=cparser.parse_cvalue()
+    ans=orjson.loads('"'+str(cparser.parse_cvalue())+'"')
     print(type(ans),ans)   
-    #print(parse_cvalue("\"{[0] = 10, [1] = 20}\""))    
+    # #print(parse_cvalue("\"{[0] = 10, [1] = 20}\""))    

--- a/debugger/src/debugger/mi_parser.py
+++ b/debugger/src/debugger/mi_parser.py
@@ -1,0 +1,134 @@
+from dataclasses import dataclass
+
+fastdataclass = lambda c: dataclass(
+    repr=False,
+    eq=False,
+    order=False,
+    frozen=True,
+    match_args=False,
+    kw_only=True,
+    slots=True,
+    weakref_slot=False,
+)(c)
+
+@fastdataclass
+class Result:
+    token: int
+    kind: str
+    results: dict
+
+
+class MIParserError(Exception):
+    pass
+
+class MIParser():
+    def __init__(self, text:str):
+        self.text=text
+        self.split_text=self.text.split("\n(gdb) \n")
+        self._sequences=iter([i.splitlines() for i in self.split_text])
+        self.advance_sequence()
+    
+    def advance_sequence(self):
+        self._current_sequence=next(self._sequences)
+        self._current_sequence_iter=iter(self._current_sequence)
+        self.advance_record()
+
+    def advance_record(self):
+        self._current_record=next(self._current_sequence_iter)
+        self._current_record_iter=iter(self._current_record)
+        self.advance()
+
+    def advance(self):
+        self._current_token=next(self._current_record_iter)
+        
+
+    def expect(self,expected: list|str):
+        if self._current_token==expected or self._current_token in expected:
+            self.advance()
+        #else:
+        #    raise MIParserError
+    
+
+    def parse_result_record(self):
+        token= self.parse_token()
+        self.expect("^")
+        kind=self.parse_result_class()
+
+        results=None
+        if self._current_token==",":
+            self.advance()            
+            results=self.parse_results()   #na
+        
+        return Result(token=token,kind=kind,results=results)
+
+            
+
+    def parse_token(self):
+        token=[]
+        while self._current_token is not None and self._current_token.isdigit():
+            token.append(self._current_token)
+            self.advance()
+        
+        return int("".join(token))
+
+
+    def parse_result_class(self):
+        kind=[]
+        print(self._current_token)
+        while self._current_token is not None and self._current_token.isalpha():
+            kind.append(self._current_token)
+            self.advance()
+        
+        #if not kind:
+            #raise MIParserError
+        
+
+        return "".join(kind)
+    
+    def parse_results(self):  #na
+        pass
+
+        
+
+
+if __name__=="__main__":
+    from textwrap import dedent
+
+    text = (
+        dedent(
+            r"""
+            12^done,stack=[frame={level="0",addr="0x0000555555555169",func="fibonacci",file="test_fibonacci.c",fullname="/app/src/debugger/test/test_fibonacci.c",line="6"},frame={level="1",addr="0x00005555555551f0",func="main",file="test_fibonacci.c",fullname="/app/src/debugger/test/test_fibonacci.c",line="16"}]
+            (gdb) 
+            10^done,__aaabada__=[x="1",x="2",x=[[["\\asdf\"1\u0000\011'"]]]]
+            =thread-exited,id="1",group-id="i1"
+            0011111^running,_="\012h'e\u0000\tl\"lo!"
+            (gdb) 
+            10^done,__aaabada__=[x="1",x="2",x=[[["\\asdf\"1\u0000\011'"]]]]
+            (gdb) 
+            10^done,x={main="0x0",crimson="\"\"]}"},y="zzz"
+            1+stopped,y={}
+            2*stopped,z={}
+            3=stopped,w={}
+            ~"helloooo~!\n"
+            @"hehehhhehe\n"
+            &"INFO:1337"
+            (gdb) 
+            """
+        )
+        .lstrip()
+        #.encode()
+    )
+    #new_text=text.split("\n(gdb) \n")
+    #print(new_text,"\n")
+
+    parse=MIParser(text)
+
+    #print(parse._current_record)
+    parse.advance_sequence()
+    print(parse._current_record,parse._current_token)
+    temp=parse.parse_result_record()
+    print(temp.token,temp.kind,temp.results)
+    #or i in parse._records:
+    #    print(i)
+    #print(iter(new_text.splitlines()))
+    #print(text,type(text))

--- a/debugger/src/debugger/mi_parser.py
+++ b/debugger/src/debugger/mi_parser.py
@@ -58,9 +58,9 @@ class LogStream:
 class MIParserError(Exception):
     pass
 
-class MIParser():
+class CursorParser():
     def __init__(self, text:str):
-        self.text=text
+        self.text=text.strip()
         self.split_text=self.text.split("\n(gdb) \n")
         self._sequences=iter([i.splitlines() for i in self.split_text])
         self.advance_sequence()
@@ -84,8 +84,9 @@ class MIParser():
             self.advance()
         else:
             raise MIParserError
-    
 
+
+class MIParser(CursorParser):
     def parse(self):
         while self._current_sequence and self._current_record:
             token= self.parse_token() if self._current_token and self._current_token.isdigit() else None
@@ -313,7 +314,81 @@ class MIParser():
 
         return "".join(async_class)
 
+
+class CValueParser(CursorParser):
+#     #"{data = 5, next = 0x0}
+#     def parse_c_values(self):
+#         match self._current_token:
+#             case :
+#                 pass
+#         self.expect("\"{")
+#         values={}
+#         values.update(self.parse_pair())
+#         if self._current_record==",":
+#             self.parse_pair()   
+
     
+        
+#         key="".join(key)
+
+        
+
+
+#     def parse_pair(self):
+#         #data = 5
+#         key=[]
+
+#         while self._current_token!="=":
+#             key.append(self._current_token)
+#             self.advance()
+        
+#         self.expect("=")
+
+
+
+    def parse_cvalue(self):
+        self.expect("\"")
+        
+        match self._current_token:
+            case t if t=="{":
+                results=dict()
+                results.update(self.parse_cvalues_struct())
+                while self._current_token==",":
+                    results.update(self.parse_cvalues_struct())
+                return results
+
+            case t if t.isdigit():
+                temp=self.text
+                if " " in self.text:
+                    temp=temp[:temp.index(" ")]
+                for j in temp:
+                    if j.isalpha():
+                        return temp
+            
+                return int(temp)  
+                    
+            case t if t.isalpha():
+                temp=self.text
+                if " " in self.text:
+                    temp=temp[:temp.index(" ")]
+                return temp
+            case _:
+                raise MIParserError(f"Unaddressed cvalue string: {text}")
+
+    def parse_cvalues_struct(self):  
+        key=[]
+
+        while self._current_token!=" ":
+            key.append(self._current_token)
+            self.advance()
+        
+        self.expect(" ")
+        self.expect("=")
+        self.expect(" ")
+
+        value=self.parse_cvalue()
+        
+        return {key:value}   
       
 
 if __name__=="__main__":
@@ -345,26 +420,30 @@ if __name__=="__main__":
         #.encode()
     )
 
+    text1=(dedent(r"""
+                  {"value": "{data = 5, next = 0x0}"}
+                  """)
+                  .lstrip()
+    )
+
     parse1=MIParser(text)
-    parse2=MIParser(text)
-    parse3=MIParser(text)
+    parse2=MIParser(text1)
 
+    # print(parse2._current_sequence)
+    # print(parse2._current_record,parse2._current_token)
 
+    
     temp1=parse1.parse()    
-    temp2=parse2.parse() 
-    temp3=parse3.parse() 
     for i in temp1:
         if isinstance(i,Result):
             print(i)
             print(i.token,i.kind,i.results)
-
-    for i in temp2:
-        if not isinstance(i,ConsoleStream) and not isinstance(i,LogStream) and not isinstance(i,TargetStream) and not isinstance(i,Result):
+        elif not isinstance(i,ConsoleStream) and not isinstance(i,LogStream) and not isinstance(i,TargetStream) and not isinstance(i,Result):
             print(i)
             print(i.token,i.kind,i.output)
-
-    for i in temp3:
-        if isinstance(i,ConsoleStream) or isinstance(i,LogStream) or isinstance(i,TargetStream):
+        elif isinstance(i,ConsoleStream) or isinstance(i,LogStream) or isinstance(i,TargetStream):
             print(i)
             print(i.msg)
     
+    print(type(parse_cvalue("098 'e' ")),parse_cvalue("098 'e' "))   
+    #print(parse_cvalue("\"{[0] = 10, [1] = 20}\""))    

--- a/debugger/src/debugger/mi_parser.py
+++ b/debugger/src/debugger/mi_parser.py
@@ -73,10 +73,12 @@ class CursorParser():
     def advance_record(self):
         self._current_record=next(self._current_sequence_iter)
         self._current_record_iter=iter(self._current_record)
+        self._pos=-1
         self.advance()
 
     def advance(self):
         self._current_token=next(self._current_record_iter,None)
+        self._pos+=1
         
 
     def expect(self,expected: list|str):
@@ -316,69 +318,76 @@ class MIParser(CursorParser):
 
 
 class CValueParser(CursorParser):
-#     #"{data = 5, next = 0x0}
-#     def parse_c_values(self):
-#         match self._current_token:
-#             case :
-#                 pass
-#         self.expect("\"{")
-#         values={}
-#         values.update(self.parse_pair())
-#         if self._current_record==",":
-#             self.parse_pair()   
-
-    
-        
-#         key="".join(key)
-
-        
-
-
-#     def parse_pair(self):
-#         #data = 5
-#         key=[]
-
-#         while self._current_token!="=":
-#             key.append(self._current_token)
-#             self.advance()
-        
-#         self.expect("=")
-
+#     #"{data = 5, next = 0x0}"
 
 
     def parse_cvalue(self):
-        self.expect("\"")
         
         match self._current_token:
             case t if t=="{":
-                results=dict()
-                results.update(self.parse_cvalues_struct())
-                while self._current_token==",":
+                print("ss",self._current_token,self._pos)
+                self.expect("{")
+                is_struct=self.lookahead_is_struct()
+                print(is_struct,self._current_token,self._pos)
+                if not is_struct:
+                    results=[]
+                    results.append(self.parse_cvalue())
+                    while self._current_token==",":
+                        self.advance()
+                        self.expect(" ")
+                        results.append(self.parse_cvalue())
+                else:
+                    results=dict()
                     results.update(self.parse_cvalues_struct())
+                    while self._current_token==",":
+                        self.advance()
+                        self.expect(" ")
+                        results.update(self.parse_cvalues_struct())
+
+                self.expect("}")
                 return results
 
             case t if t.isdigit():
-                temp=self.text
-                if " " in self.text:
-                    temp=temp[:temp.index(" ")]
-                for j in temp:
-                    if j.isalpha():
-                        return temp
-            
-                return int(temp)  
+                alias=False
+                is_addr=False
+                sub_val=[]
+                while self._current_token!="," and self._current_token!="}" and self._current_token!=None:
+                    if self._current_token==" ":
+                        alias=True
+                    
+                    if alias:
+                        self.advance()
+                        continue
+
+                    if self._current_token.isalpha():
+                        is_addr=True                   
+
+                    sub_val.append(self._current_token)
+                    self.advance()
+
+                if is_addr:
+                    return "".join(sub_val)
+                else:
+                    return int("".join(sub_val))  
                     
             case t if t.isalpha():
-                temp=self.text
-                if " " in self.text:
-                    temp=temp[:temp.index(" ")]
-                return temp
+                sub_str=[]
+                while self._current_token!="," or self._current_token=="}" or self._current_token==None:
+                    sub_str.append(self._current_token)
+                    self.advance()    
+                return "".join("".join(sub_str))
+            
             case _:
                 raise MIParserError(f"Unaddressed cvalue string: {text}")
 
-    def parse_cvalues_struct(self):  
+    def parse_cvalues_struct(self):
         key=[]
 
         while self._current_token!=" ":
+            if self._current_record==",":
+                is_list=True
+                break
+    
             key.append(self._current_token)
             self.advance()
         
@@ -387,8 +396,23 @@ class CValueParser(CursorParser):
         self.expect(" ")
 
         value=self.parse_cvalue()
+        key="".join(key)
         
-        return {key:value}   
+        return {key:value}
+        
+    def lookahead_is_struct(self) -> bool:
+        i = self._pos+1
+        while i < len(self._current_record):
+            c = self._current_record[i]
+            if c == '=':
+                return True
+            if c in (',', '}', '{'):
+                return False
+            i += 1
+        return False
+
+
+
       
 
 if __name__=="__main__":
@@ -429,21 +453,24 @@ if __name__=="__main__":
     parse1=MIParser(text)
     parse2=MIParser(text1)
 
-    # print(parse2._current_sequence)
-    # print(parse2._current_record,parse2._current_token)
-
+    # temp1=parse1.parse()    
+    # for i in temp1:
+    #     if isinstance(i,Result):
+    #         print(i)
+    #         print(i.token,i.kind,i.results)
+    #     elif not isinstance(i,ConsoleStream) and not isinstance(i,LogStream) and not isinstance(i,TargetStream) and not isinstance(i,Result):
+    #         print(i)
+    #         print(i.token,i.kind,i.output)
+    #     elif isinstance(i,ConsoleStream) or isinstance(i,LogStream) or isinstance(i,TargetStream):
+    #         print(i)
+    #         print(i.msg)
     
-    temp1=parse1.parse()    
-    for i in temp1:
-        if isinstance(i,Result):
-            print(i)
-            print(i.token,i.kind,i.results)
-        elif not isinstance(i,ConsoleStream) and not isinstance(i,LogStream) and not isinstance(i,TargetStream) and not isinstance(i,Result):
-            print(i)
-            print(i.token,i.kind,i.output)
-        elif isinstance(i,ConsoleStream) or isinstance(i,LogStream) or isinstance(i,TargetStream):
-            print(i)
-            print(i.msg)
-    
-    print(type(parse_cvalue("098 'e' ")),parse_cvalue("098 'e' "))   
+    text="""10^done,value="{point = {x = 1, y = 2}, arr = {10, 20}, chk = {{x = 10, y = 20}, {x = 30, y = 40}, {x = 50, y = 60}}, ptr = 0x5555555592a0 ', ch = 101 'e'}" """.strip(" ")
+    value=MIParser(text).parse()
+    value=next(value).results['value']
+    print(value)
+    cparser=CValueParser(value)
+    print(cparser._current_token)
+    ans=cparser.parse_cvalue()
+    print(type(ans),ans)   
     #print(parse_cvalue("\"{[0] = 10, [1] = 20}\""))    

--- a/debugger/src/debugger/mi_parser.py
+++ b/debugger/src/debugger/mi_parser.py
@@ -81,12 +81,27 @@ class MIParser():
     def expect(self,expected: list|str):
         if self._current_token==expected or self._current_token in expected:
             self.advance()
-        #else:
-        #    raise MIParserError
+        else:
+            raise MIParserError
     
 
-    def parse_result_record(self):
-        token= self.parse_token() if self._current_token!="^" else ""
+    def parse(self):
+        while self._current_sequence and self._current_record:
+            token= self.parse_token() if self._current_token.isdigit() else ""
+            match self._current_token:
+                case "^":
+                    self.parse_result_record(token)
+                case _:
+                    self.parse_ofb_record(token)
+            try:
+                self.advance_record()
+            except StopIteration:
+                try:
+                    self.advance_sequence()
+                except StopIteration:
+                    break
+
+    def parse_result_record(self, token: str):
         self.expect("^")
         kind=self.parse_result_class()
 
@@ -204,12 +219,12 @@ class MIParser():
         self.expect("\"")
         return "".join(cstring)
     
-    def parse_ofb_record(self):
+    def parse_ofb_record(self, token: str):
         match self._current_token:
             case "~" | "@" | "&":
                 return self.parse_stream_record()
             case _:
-                return self.parse_async_record()
+                return self.parse_async_record(str)
         
 
     def parse_async_record(self):

--- a/debugger/src/debugger/mi_parser.py
+++ b/debugger/src/debugger/mi_parser.py
@@ -59,8 +59,11 @@ class MIParserError(Exception):
     pass
 
 class CursorParser():
-    def __init__(self, text:str):
-        self.text=text.lstrip()
+    def __init__(self, text: bytes|str):
+        if isinstance(text,bytes):
+            self.text=text.decode()
+        else:
+            self.text=text
         self.split_text=self.text.split("\n(gdb) \n")
         self._sequences=iter([i.splitlines() for i in self.split_text])
         self.advance_sequence()
@@ -90,6 +93,9 @@ class CursorParser():
 
 class MIParser(CursorParser):
     def parse(self):
+        if self._current_token in ("", "("):
+            return
+        
         while self._current_sequence and self._current_record:
             token= self.parse_token() if self._current_token and self._current_token.isdigit() else None
             match self._current_token:
@@ -326,7 +332,7 @@ class CValueParser(CursorParser):
         self.advance()
 
     def parse_cvalue(self):       
-        print("ss",self._current_token,self._pos) 
+        #print("ss",self._current_token,self._pos) 
         match self._current_token:
             case t if t=="{":
                 
@@ -344,7 +350,7 @@ class CValueParser(CursorParser):
                     return results
                     
                 is_struct=self.lookahead_is_struct()
-                print(is_struct,self._current_token,self._pos)
+                #print(is_struct,self._current_token,self._pos)
                 if not is_struct:
                     results=[]
                     results.append(self.parse_cvalue())
@@ -418,7 +424,7 @@ class CValueParser(CursorParser):
         value=self.parse_cvalue()
         key="".join(key)
 
-        print({key:value})        
+        #print({key:value})        
         return {key:value}
         
     def lookahead_is_struct(self) -> bool:
@@ -431,7 +437,6 @@ class CValueParser(CursorParser):
                 return False
             i += 1
         return False
-
 
 
       
@@ -463,40 +468,53 @@ if __name__=="__main__":
             (gdb) 
             """)
         .lstrip()
-        #.encode()
+        .encode()
     )
 
     parse1=MIParser(text)
   
 
-    # temp1=parse1.parse()    
-    # for i in temp1:
-    #     if isinstance(i,Result):
-    #         print(i)
-    #         print(i.token,i.kind,i.results)
-    #     elif not isinstance(i,ConsoleStream) and not isinstance(i,LogStream) and not isinstance(i,TargetStream) and not isinstance(i,Result):
-    #         print(i)
-    #         print(i.token,i.kind,i.output)
-    #     elif isinstance(i,ConsoleStream) or isinstance(i,LogStream) or isinstance(i,TargetStream):
-    #         print(i)
-    #         print(repr(i.msg),i.msg)
+    temp1=parse1.parse()    
+    for i in temp1:
+        if isinstance(i,Result):
+            print(i)
+            print(i.token,i.kind,i.results)
+        elif not isinstance(i,ConsoleStream) and not isinstance(i,LogStream) and not isinstance(i,TargetStream) and not isinstance(i,Result):
+            print(i)
+            print(i.token,i.kind,i.output)
+        elif isinstance(i,ConsoleStream) or isinstance(i,LogStream) or isinstance(i,TargetStream):
+            print(i)
+            print(repr(i.msg),i.msg)
     
- 
-    # text="""10^done,value="{point = {x = 1, y = 2}, arr = {10, 20}, chk = {{x = 10, y = 20}, {x = 30, y = 40}, {x = 50, y = 60}}, ptr = 0x5555555592a0 ', ch = 101 'e'}" """.strip(" ")
-    # value=MIParser(text).parse()
-    # value=next(value).results['value']
-    # print(value)
-    # cparser=CValueParser(value)
-    # print(cparser._current_token)
-    # ans=cparser.parse_cvalue()
-    # print(type(ans),ans)
+    cvaluestring_cases = dedent(r"""
+                10^done,value="10"
+                11^done,value="-42"
+                12^done,value="3.14"
+                13^done,value="0x0"
+                14^done,value="0x5555555592a0 <main>"
+                15^done,value="{x = 101 'e', y = 2}"
+                16^done,value="{10, 20, 30}"
+                17^done,value="{scalar = 1, flag = 0, msg = \"hello\012world\", tab_str = \"col1\011col2\", null_str = \"null\000byte\", nested2 = {a = 1, b = 2}, nested3 = {outer = {mid = {inner = 42}}, sibling = 99}, vec3d = {x = 1.5, y = 2.5, z = 3.5}, transform = {pos = {x = 1.0, y = 2.0, z = 3.0}, rot = {x = 0.0, y = 0.0, z = 1.0}, scale = 2.5}, arr_int = {10, 20, 30}, arr_struct = {{x = 1, y = 2}, {x = 3, y = 4}, {x = 5, y = 6}}, arr_nested = {{p = {a = 1, b = 2}, q = 3}, {p = {a = 4, b = 5}, q = 6}}, mixed = {count = 3, data = {100, 200, 300}, info = {id = 7, val = 8}}, zero_addr = 0x0, neg = -42, big = 2147483647}"
+                18^done,value="{node = {data = 5, next = 0x0}, ptr = 0x5555555592a0}"
+                19^done,value="{arr_struct = {{x = 1, y = 2}, {x = 3, y = 4}}}"
+                20^done,value="{strs = {\"a\", \"b\", \"hello\012world\"}}"
+                """).strip()
 
+    for line in cvaluestring_cases.splitlines():
+        print("\n")
+        print("MI record:")
+        print(line)
 
-    text=dedent(r"""10^done,value="{scalar = 1, flag = 0, msg = \"hello\012world\", tab_str = \"col1\011col2\", null_str = \"null\000byte\", nested2 = {a = 1, b = 2}, nested3 = {outer = {mid = {inner = 42}}, sibling = 99}, vec3d = {x = 1.5, y = 2.5, z = 3.5}, transform = {pos = {x = 1.0, y = 2.0, z = 3.0}, rot = {x = 0.0, y = 0.0, z = 1.0}, scale = 2.5}, arr_int = {10, 20, 30}, arr_struct = {{x = 1, y = 2}, {x = 3, y = 4}, {x = 5, y = 6}}, arr_nested = {{p = {a = 1, b = 2}, q = 3}, {p = {a = 4, b = 5}, q = 6}}, mixed = {count = 3, data = {100, 200, 300}, info = {id = 7, val = 8}}, zero_addr = 0x0, neg = -42, big = 2147483647}" """.strip(" "))
-    #text=r"""10^done,value="10" """.strip()
-    value=MIParser(text).parse()
-    value=next(value).results['value']
-    cparser=CValueParser(value)
-    ans=orjson.loads('"'+str(cparser.parse_cvalue())+'"')
-    print(type(ans),ans)   
-    # #print(parse_cvalue("\"{[0] = 10, [1] = 20}\""))    
+        try:
+            record = next(MIParser(line.encode()).parse())
+            raw_value = record.results["value"]
+
+            print("Parse MI string:")
+            print(repr(raw_value))
+
+            parsed_value = CValueParser(raw_value).parse_cvalue()
+
+            print("Parsed cvalue string:")
+            print(type(parsed_value), parsed_value)
+        except:
+            raise MIParserError

--- a/debugger/src/debugger/mi_parser.py
+++ b/debugger/src/debugger/mi_parser.py
@@ -39,7 +39,7 @@ class MIParser():
         self.advance()
 
     def advance(self):
-        self._current_token=next(self._current_record_iter)
+        self._current_token=next(self._current_record_iter,None)
         
 
     def expect(self,expected: list|str):
@@ -50,14 +50,14 @@ class MIParser():
     
 
     def parse_result_record(self):
-        token= self.parse_token()
+        token= self.parse_token() if self._current_token!="^" else ""
         self.expect("^")
         kind=self.parse_result_class()
 
-        results=None
-        if self._current_token==",":
+        results=dict()
+        while self._current_token==",":
             self.advance()            
-            results=self.parse_results()   #na
+            results.update(self.parse_result())   #na
         
         return Result(token=token,kind=kind,results=results)
 
@@ -85,8 +85,90 @@ class MIParser():
 
         return "".join(kind)
     
-    def parse_results(self):  #na
-        pass
+    def parse_result(self):  #na
+        key=[]
+
+        while self._current_token.isalpha() or self._current_token in ["_","-"]:
+            key.append(self._current_token)
+            self.advance()
+        
+        self.expect("=")
+        value=self.parse_values()
+        variable="".join(key)
+        print(self._current_token)
+
+        return {variable:value}
+    
+
+
+    def parse_values(self):
+        temp_value=None
+        match self._current_token:
+            case "[":
+                #self.expect("[")
+                temp_value=self.parse_list()
+            case "{":
+                temp_value=self.parse_tuple()
+            case "\"":
+                temp_value=self.parse_cstring()
+            case _:
+                raise MIParserError
+            
+        return temp_value
+            
+                         
+        
+    def parse_list(self):
+        self.expect("[")
+        value_list=[]
+        match self._current_token:
+            case "]":
+                self.expect("]")
+                return value_list
+            case "[" | "\"" | "{":
+                value_list.append(self.parse_values())
+                while self._current_token==",":
+                    self.expect(",")
+                    value_list.append(self.parse_values())
+            case _:
+                value_list.append(self.parse_result())
+                while self._current_token==",":
+                    self.expect(",")
+                    value_list.append(self.parse_result())
+
+        self.expect("]")        
+
+        return value_list
+
+    # variable=[var:val,var1:[var2:val2]]
+                    
+
+    def parse_tuple(self):
+        self.expect("{")
+        value_tuple={}
+        match self._current_token:
+            case "}":
+                self.expect("}")
+                return value_tuple
+            case _:
+                value_tuple.update(self.parse_result())
+                while self._current_token==",":
+                    self.expect(",")
+                    value_tuple.update(self.parse_result())
+        
+        self.expect("}")
+        return value_tuple
+
+    def parse_cstring(self):
+        self.expect("\"")
+        cstring=[]
+        while self._current_token!="\"":
+            cstring.append(self._current_token)
+            self.advance()
+        self.expect("\"")
+        return "".join(cstring)
+      
+
 
         
 
@@ -120,11 +202,12 @@ if __name__=="__main__":
     )
     #new_text=text.split("\n(gdb) \n")
     #print(new_text,"\n")
+    #print(text)
 
     parse=MIParser(text)
 
     #print(parse._current_record)
-    parse.advance_sequence()
+    #parse.advance_sequence()
     print(parse._current_record,parse._current_token)
     temp=parse.parse_result_record()
     print(temp.token,temp.kind,temp.results)

--- a/debugger/src/debugger/mi_parser.py
+++ b/debugger/src/debugger/mi_parser.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+import orjson
 
 fastdataclass = lambda c: dataclass(
     repr=False,
@@ -87,12 +88,12 @@ class MIParser():
 
     def parse(self):
         while self._current_sequence and self._current_record:
-            token= self.parse_token() if self._current_token.isdigit() else ""
+            token= self.parse_token() if self._current_token and self._current_token.isdigit() else None
             match self._current_token:
                 case "^":
-                    self.parse_result_record(token)
+                    yield self.parse_result_record(token)
                 case _:
-                    self.parse_ofb_record(token)
+                    yield self.parse_ofb_record(token)
             try:
                 self.advance_record()
             except StopIteration:
@@ -125,18 +126,17 @@ class MIParser():
 
     def parse_result_class(self):
         kind=[]
-        print(self._current_token)
         while self._current_token is not None and self._current_token.isalpha():
             kind.append(self._current_token)
             self.advance()
         
-        #if not kind:
-            #raise MIParserError
+        if not kind:
+            raise MIParserError
         
 
         return "".join(kind)
     
-    def parse_result(self):  #na
+    def parse_result(self):  
         key=[]
 
         while self._current_token.isalpha() or self._current_token in ["_","-"]:
@@ -146,7 +146,6 @@ class MIParser():
         self.expect("=")
         value=self.parse_values()
         variable="".join(key)
-        print(self._current_token)
 
         return {variable:value}
     
@@ -182,10 +181,10 @@ class MIParser():
                     self.expect(",")
                     value_list.append(self.parse_values())
             case _:
-                value_list.append(self.parse_result())
+                value_list.extend(self.parse_result().values())
                 while self._current_token==",":
                     self.expect(",")
-                    value_list.append(self.parse_result())
+                    value_list.extend(self.parse_result().values())
 
         self.expect("]")        
 
@@ -212,23 +211,55 @@ class MIParser():
 
     def parse_cstring(self):
         self.expect("\"")
+        escape=False
         cstring=[]
-        while self._current_token!="\"":
+        while self._current_token:
+            if escape is False and self._current_token=="\"":
+                break
+
+            if escape:
+                oct_str=[]
+                cnt=0
+                while cnt<3:
+                    if self._current_token.isdigit() and 0<=int(self._current_token)<=7:
+                        oct_str.append(self._current_token)
+                        self.advance()
+                    else:
+                        break
+                    cnt+=1
+                
+                if cnt>0:
+                    cstring.append("u")
+                    oct_str=int("".join(oct_str),8)
+                    hex_str=f"{oct_str:04x}"
+                    cstring.extend(list(hex_str))
+                    
+                    escape=False    
+                    continue      
+
+            if self._current_token=="\\":
+                escape=True
+            else:
+                escape=False 
+                          
             cstring.append(self._current_token)
             self.advance()
+     
+        
         self.expect("\"")
-        return "".join(cstring)
-    
+        return orjson.loads('"'+"".join(cstring)+'"')
+
+
+
     def parse_ofb_record(self, token: str):
         match self._current_token:
             case "~" | "@" | "&":
                 return self.parse_stream_record()
             case _:
-                return self.parse_async_record(str)
+                return self.parse_async_record(token)
         
 
-    def parse_async_record(self):
-        token=self.parse_token()
+    def parse_async_record(self,token: str):
         match self._current_token:
             case "*":
                 self.expect("*")
@@ -291,10 +322,13 @@ if __name__=="__main__":
     text = (
         dedent(
             r"""
+            @"hehehhhehe\u0000\011\n"
+            ~"helloooo~!\n"
+            ~"\\asdf\"1\u0000\011'"
+            &"INFO:1337"
             12^done,stack=[frame={level="0",addr="0x0000555555555169",func="fibonacci",file="test_fibonacci.c",fullname="/app/src/debugger/test/test_fibonacci.c",line="6"},frame={level="1",addr="0x00005555555551f0",func="main",file="test_fibonacci.c",fullname="/app/src/debugger/test/test_fibonacci.c",line="16"}]
-            (gdb) 
             10^done,__aaabada__=[x="1",x="2",x=[[["\\asdf\"1\u0000\011'"]]]]
-            =thread-exited,id="1",group-id="i1"
+            13^done,a=[b=[[c="2"],[d="3"]]]
             0011111^running,_="\012h'e\u0000\tl\"lo!"
             (gdb) 
             10^done,__aaabada__=[x="1",x="2",x=[[["\\asdf\"1\u0000\011'"]]]]
@@ -302,35 +336,35 @@ if __name__=="__main__":
             10^done,x={main="0x0",crimson="\"\"]}"},y="zzz"
             1+stopped,y={}
             2*stopped,z={}
-            3=stopped,w={}
-            ~"helloooo~!\n"
-            @"hehehhhehe\n"
-            &"INFO:1337"
+            3=stopped,w={}            
             (gdb) 
-            """
-        )
+            ~"what\012"
+            (gdb) 
+            """)
         .lstrip()
         #.encode()
     )
-    #new_text=text.split("\n(gdb) \n")
-    #print(new_text,"\n")
-    #print(text)
 
-    parse=MIParser(text)
+    parse1=MIParser(text)
+    parse2=MIParser(text)
+    parse3=MIParser(text)
 
-    #print(parse._current_record)
-    parse.advance_sequence()
-    parse.advance_sequence()
-    parse.advance_sequence()
-    parse.advance_record()
-    parse.advance_record()
-    parse.advance_record()
-    parse.advance_record()
-    print(parse._current_record,parse._current_token)
-    temp=parse.parse_ofb_record()
-    #print(temp.token,temp.kind,temp.output)
-    print(temp,temp.msg)
-    #or i in parse._records:
-    #    print(i)
-    #print(iter(new_text.splitlines()))
-    #print(text,type(text))
+
+    temp1=parse1.parse()    
+    temp2=parse2.parse() 
+    temp3=parse3.parse() 
+    for i in temp1:
+        if isinstance(i,Result):
+            print(i)
+            print(i.token,i.kind,i.results)
+
+    for i in temp2:
+        if not isinstance(i,ConsoleStream) and not isinstance(i,LogStream) and not isinstance(i,TargetStream) and not isinstance(i,Result):
+            print(i)
+            print(i.token,i.kind,i.output)
+
+    for i in temp3:
+        if isinstance(i,ConsoleStream) or isinstance(i,LogStream) or isinstance(i,TargetStream):
+            print(i)
+            print(i.msg)
+    

--- a/debugger/src/debugger/test/tools.py
+++ b/debugger/src/debugger/test/tools.py
@@ -2,7 +2,8 @@ from asyncio import gather
 from contextlib import asynccontextmanager
 from pathlib import Path
 
-from debugger import c_compile, mi
+from debugger import c_compile
+from debugger import mi_parser as mi
 from debugger.debugger import Debugger
 
 


### PR DESCRIPTION
Closes #791

- Added `mi_parser.py` with a recursive descent parser for GDB/MI output.
- Added C-string parsing support for MI stream results when calling "-data-evaluate-expression"
- Updated all parser imports to use `mi_parser.py` instead of `mi.py`.
- Ran existing debugger tests
- Ran some local parser parity checks against the old `mi.py` to check for consistency