### PR TITLE
fix(ci): remove invalid Renovate preset extends for Vite rules. #773

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -44,16 +44,32 @@
       "addLabels": ["deps: vite"]
     },
     {
-      "extends": [":description=Base rule for all Vite-related packages"],
+      "description": "Vite-related packages: major updates",
+      "matchPackageNames": [
+        "vite",
+        "@vitejs/plugin-react",
+        "vite-plugin-checker",
+        "vite-tsconfig-paths"
+      ],
       "matchUpdateTypes": ["major"],
       "groupName": "vite & plugins (major)",
+      "enabled": true,
+      "addLabels": ["deps: vite"],
       "automerge": false,
       "schedule": ["before 5am on the first monday of every 5th month"]
     },
     {
-      "extends": [":description=Base rule for all Vite-related packages"],
+      "description": "Vite-related packages: minor/patch updates",
+      "matchPackageNames": [
+        "vite",
+        "@vitejs/plugin-react",
+        "vite-plugin-checker",
+        "vite-tsconfig-paths"
+      ],
       "matchUpdateTypes": ["minor", "patch"],
       "groupName": "vite & plugins (minor/patch)",
+      "enabled": true,
+      "addLabels": ["deps: vite"],
       "automerge": false,
       "schedule": ["before 5am on the first monday of every 3rd month"]
     }

--- a/renovate.json
+++ b/renovate.json
@@ -2,26 +2,25 @@
   "extends": [],
   "lockFileMaintenance": { "enabled": true, "automerge": true },
   "prHourlyLimit": 4,
-  "prMonthlyLimit": 6,
   "labels": ["dependencies"],
   "reviewersFromCodeOwners": true,
   "packageRules": [
     {
-      "matchPackagePatterns": [".*"],
+      "matchPackagePatterns": ["/.*/"],
       "enabled": false
     },
     {
       "groupName": "ci-actions",
-      "managers": ["github-actions", "dockerfile"],
+      "matchManagers": ["github-actions", "dockerfile"],
       "enabled": true,
       "automerge": false,
       "automergeType": "branch",
       "addLabels": ["deps: ci-actions"],
-      "schedule": ["before 5am on the first monday of every 4th month"]
+      "schedule": ["* 0-4 * */4 1#1"]
     },
     {
       "matchPackageNames": ["actions/checkout", "actions/setup-node"],
-      "managers": ["github-actions"],
+      "matchManagers": ["github-actions"],
       "enabled": true,
       "automerge": true,
       "automergeType": "branch",
@@ -56,7 +55,7 @@
       "enabled": true,
       "addLabels": ["deps: vite"],
       "automerge": false,
-      "schedule": ["before 5am on the first monday of every 5th month"]
+      "schedule": ["* 0-4 * */5 1#1"]
     },
     {
       "description": "Vite-related packages: minor/patch updates",
@@ -71,7 +70,7 @@
       "enabled": true,
       "addLabels": ["deps: vite"],
       "automerge": false,
-      "schedule": ["before 5am on the first monday of every 3rd month"]
+      "schedule": ["* 0-4 * */3 1#1"]
     }
   ]
 }


### PR DESCRIPTION
## Summary
This PR is related to issue #773.

Fixes Renovate configuration errors that were blocking dependency update PRs on `dev`.

Resolves the bot error:
> Cannot find preset's package (:description=Base rule for all Vite-related packages)

Also fixes additional validation issues found when running `renovate-config-validator` locally.

## Changes

### Fix invalid Vite package rule inheritance

- Removed invalid `extends: [":description=Base rule for all Vite-related packages"]` from Vite major and minor/patch rules
- Inlined `matchPackageNames` explicitly in both rules
- `description` on a `packageRule` is documentation only — it cannot be referenced via `extends`

### Replace natural-language schedules with cron

| Rule | Before | After |
|------|--------|-------|
| CI actions | `before 5am on the first monday of every 4th month` | `* 0-4 * */4 1#1` |
| Vite major | `before 5am on the first monday of every 5th month` | `* 0-4 * */5 1#1` |
| Vite minor/patch | `before 5am on the first monday of every 3rd month` | `* 0-4 * */3 1#1` |

Cron mapping:
- `0-4` → before 5am
- `1#1` → first Monday of the month
- `*/N` → every Nth month (calendar-aligned)

### Remove invalid config option

- Removed `prMonthlyLimit` (not a supported Renovate option)
- Kept `prHourlyLimit: 4` for rate limiting

### Migrate deprecated field names

- `managers` → `matchManagers`
- `matchPackagePatterns: [".*"]` → `matchPackagePatterns: ["/.*/"]`

## Validation

```bash
npx --yes --package renovate renovate-config-validator renovate.json