### PR TITLE
feature(debugger): added cpu telemetry with pyroscope (#739)

### DIFF
--- a/debugger/requirements.txt
+++ b/debugger/requirements.txt
@@ -28,3 +28,4 @@ typing_extensions==4.13.2
 uvicorn==0.34.0
 wsproto==1.2.0
 yappi==1.6.10
+pyroscope-io==1.0.5

--- a/debugger/src/debugger/debugger.py
+++ b/debugger/src/debugger/debugger.py
@@ -7,6 +7,13 @@ from pydantic import BaseModel
 from . import mi_parser as mi
 from .base_debugger import BaseDebugger
 
+import pyroscope
+
+pyroscope.configure(
+  application_name = "structs.sh", # replace this with some name for your application
+  server_address   = "http://localhost:4040", # replace this with the address of your Pyroscope server
+)
+
 
 class Identity[T](BaseModel):  # legacy
     item: T
@@ -154,60 +161,62 @@ class Debugger(BaseDebugger):
                     # It is a struct field
                     fmt_childs.append(f"({var}.{subname})")
             return fmt_childs
+        
+        with pyroscope.tag_wrapper({ "task": "generate_memory_graph" }):
 
-        frames = list[FrameInfo]()
-        mem = defaultdict[str, dict[str, MemObj]](dict)
-        legacy_fmt: dict[str, list[tuple[str | int, str]]] = {}  # legacy
+            frames = list[FrameInfo]()
+            mem = defaultdict[str, dict[str, MemObj]](dict)
+            legacy_fmt: dict[str, list[tuple[str | int, str]]] = {}  # legacy
 
-        for i, frame in enumerate(await self.frames()):
-            queue = deque()
+            for i, frame in enumerate(await self.frames()):
+                queue = deque()
 
-            variabs = dict[str, MemObj]()
-            for var in await self.variables(i):
-                kind, value, addr, childs = await self.var_details(var, i)
-                variabs[var] = MemObj(kind=kind, value=value, addr=addr)
-                mem[addr][kind] = MemObj(kind=kind, value=value, addr=addr)
-                if childs and not kind.endswith("*"):
-                    legacy_fmt[kind] = childs
-                if value != "0x0" and kind != "void *":
-                    queue.extend(follow(var, kind, childs))
-            frames.append(FrameInfo(frame=frame, vars=variabs))
-
-            while queue:
-                var = queue.popleft()
-                try:
+                variabs = dict[str, MemObj]()
+                for var in await self.variables(i):
                     kind, value, addr, childs = await self.var_details(var, i)
-                except ValueError:
-                    continue
-                if mem[addr].get(kind):
-                    continue
-                mem[addr][kind] = MemObj(kind=kind, value=value, addr=addr)
-                if (
-                    childs
-                    and not kind.endswith("*")
-                    and not kind.endswith("[]")
-                ):
-                    try:
+                    variabs[var] = MemObj(kind=kind, value=value, addr=addr)
+                    mem[addr][kind] = MemObj(kind=kind, value=value, addr=addr)
+                    if childs and not kind.endswith("*"):
                         legacy_fmt[kind] = childs
-                        mem[addr][kind] = MemObj(
-                            kind=kind,
-                            value={
-                                name: MemObj(
-                                    kind=kind, value=value[name], addr=None
-                                )
-                                for name, kind in childs
-                            },
-                            addr=addr,
-                        )  # legacy
-                    except Exception:
-                        assert False, (
-                            [(name, kind) for name, kind in childs],
-                            value,
-                        )
-                if value != "0x0" and kind != "void *":
-                    queue.extend(follow(var, kind, childs))
+                    if value != "0x0" and kind != "void *":
+                        queue.extend(follow(var, kind, childs))
+                frames.append(FrameInfo(frame=frame, vars=variabs))
 
-        return Trace(frames=frames, mem=mem, structs=legacy_fmt)
+                while queue:
+                    var = queue.popleft()
+                    try:
+                        kind, value, addr, childs = await self.var_details(var, i)
+                    except ValueError:
+                        continue
+                    if mem[addr].get(kind):
+                        continue
+                    mem[addr][kind] = MemObj(kind=kind, value=value, addr=addr)
+                    if (
+                        childs
+                        and not kind.endswith("*")
+                        and not kind.endswith("[]")
+                    ):
+                        try:
+                            legacy_fmt[kind] = childs
+                            mem[addr][kind] = MemObj(
+                                kind=kind,
+                                value={
+                                    name: MemObj(
+                                        kind=kind, value=value[name], addr=None
+                                    )
+                                    for name, kind in childs
+                                },
+                                addr=addr,
+                            )  # legacy
+                        except Exception:
+                            assert False, (
+                                [(name, kind) for name, kind in childs],
+                                value,
+                            )
+                    if value != "0x0" and kind != "void *":
+                        queue.extend(follow(var, kind, childs))
+
+            return Trace(frames=frames, mem=mem, structs=legacy_fmt)
 
     async def legacy_trace(self):
         frame = (await self.frames())[0]

--- a/debugger/src/debugger/debugger.py
+++ b/debugger/src/debugger/debugger.py
@@ -6,13 +6,17 @@ from pydantic import BaseModel
 
 from . import mi_parser as mi
 from .base_debugger import BaseDebugger
-
 import pyroscope
 
 pyroscope.configure(
-  application_name = "structs.sh", # replace this with some name for your application
-  server_address   = "http://localhost:4040", # replace this with the address of your Pyroscope server
+    application_name = "structs.sh",
+    server_address   = "http://pyroscope:4040"
 )
+
+try:
+    pyroscope.start()
+except Exception:
+    pass
 
 
 class Identity[T](BaseModel):  # legacy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
     volumes:
       - ./client/src:/app/src
       - vite-cache:/app/node_modules/.vite
+      
   debugger:
     build:
       context: debugger
@@ -22,3 +23,16 @@ services:
 
 volumes:
   vite-cache:
+  pyroscope:
+    image: grafana/pyroscope:latest
+    ports:
+      - "4040:4040"
+    command: ["server"]
+
+  grafana:
+    image: grafana/grafana:latest
+    ports:
+      - "9000:3000"
+    environment:
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,8 +21,6 @@ services:
     volumes:
       - ./debugger/src:/app/src
 
-volumes:
-  vite-cache:
   pyroscope:
     image: grafana/pyroscope:latest
     ports:
@@ -36,3 +34,8 @@ volumes:
     environment:
       - GF_AUTH_ANONYMOUS_ENABLED=true
       - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+    volumes:
+      - ./grafana/provisioning:/etc/grafana/provisioning
+
+volumes:
+  vite-cache:

--- a/grafana/provisioning/datasources/pyroscope.yml
+++ b/grafana/provisioning/datasources/pyroscope.yml
@@ -1,0 +1,9 @@
+apiVersion: 1
+
+datasources:
+  - name: Grafana Pyroscope
+    type: grafana-pyroscope-datasource
+    access: proxy
+    url: http://pyroscope:4040
+    jsonData:
+      minStep: '15s'


### PR DESCRIPTION
Added pyroscope and grafana instances to the docker compose file.

Added a config file to grafana/provisioning/datasources to connect the pyroscope server to grafana on startup.

Added a wrapper to track the trace function in debugger.py. This is for ease of use when trying to see the telemetry of a specific code block, this can be done for any code block, I just used debugger.py as an example.

Once grafana and pyroscope are running, you can either go to localhost:4040 to see the telemetry through pyroscope or to localhost:9000 and then go to profiles to see the telemetry through grafana.